### PR TITLE
fix: unregister salary field when salary type is set to RANGE + home Page +  Signout button 

### DIFF
--- a/app/(guest)/signin/page.tsx
+++ b/app/(guest)/signin/page.tsx
@@ -1,3 +1,4 @@
+import NotSignIn from "@/components/NotSignIn";
 import { signIn } from "@/lib/auth";
 import { providerFortyTwo } from "@/lib/auth";
 import Image from "next/image";
@@ -5,27 +6,7 @@ import Image from "next/image";
 export default function Layout() {
   return (
     <main className="flex flex-col items-center justify-center h-screen">
-      <form
-        action={async () => {
-          "use server";
-          await signIn(providerFortyTwo.id, {
-            redirectTo: "/dashboard",
-          });
-        }}
-      >
-        <button
-          type="submit"
-          className="flex items-center gap-6 font-bold bg-white text-black px-4 py-1 rounded"
-        >
-          <Image
-            src="https://upload.wikimedia.org/wikipedia/commons/8/8d/42_Logo.svg"
-            width={40}
-            height={40}
-            alt="42"
-          />
-          Sign in with 42
-        </button>
-      </form>
+      <NotSignIn />
     </main>
   );
 }

--- a/app/(guest)/signin/page.tsx
+++ b/app/(guest)/signin/page.tsx
@@ -1,8 +1,4 @@
 import NotSignIn from "@/components/NotSignIn";
-import { signIn } from "@/lib/auth";
-import { providerFortyTwo } from "@/lib/auth";
-import Image from "next/image";
-
 export default function Layout() {
   return (
     <main className="flex flex-col items-center justify-center h-screen">

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,6 +1,5 @@
 import { ReviewModalComponent } from "@/components/review-modal";
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
-import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,12 +1,13 @@
 import { ReviewModalComponent } from "@/components/review-modal";
 import { Avatar, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { auth } from "@/lib/auth";
+import { auth, signOut } from "@/lib/auth";
 import prisma from "@/lib/prisma";
 import { CompanyType } from "@/lib/types";
 import { AvatarFallback } from "@radix-ui/react-avatar";
@@ -56,7 +57,17 @@ export default async function Layout({
 
             <DropdownMenuContent>
               <DropdownMenuItem>Settings</DropdownMenuItem>
-              <DropdownMenuItem>Sign Out</DropdownMenuItem>
+              <form
+                action={async () => {
+                  "use server";
+                  await signOut();
+                }}
+                className="w-full"
+              >
+                <DropdownMenuItem>
+                  <button>Sign Out</button>
+                </DropdownMenuItem>
+              </form>
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/components/NotSignIn.tsx
+++ b/components/NotSignIn.tsx
@@ -10,7 +10,7 @@ const quotes = [
 export default function NotSignIn() {
   const selectedQuote = quotes[Math.floor(Math.random() * quotes.length)];
   return (
-    <section className="w-full py-12 md:py-24 lg:py-32 xl:py-48">
+    <section className="py-12 md:py-24 lg:py-32 xl:py-48">
       <div className="container px-4 md:px-6 flex flex-col items-center text-center space-y-6">
         <div className="flex flex-col space-y-4">
           <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl xl:text-6xl">

--- a/components/NotSignIn.tsx
+++ b/components/NotSignIn.tsx
@@ -45,6 +45,7 @@ function _42Icon(props: React.SVGProps<SVGSVGElement>) {
       viewBox="0 0 24 24"
       fill="none"
       xmlns="http://www.w3.org/2000/svg"
+      {...props}
     >
       <path
         d="M0.799988 15.3149H9.05249V19.4499H13.17V11.9774H4.93249L13.17 3.72241H9.05249L0.799988 11.9774V15.3149Z"

--- a/components/NotSignIn.tsx
+++ b/components/NotSignIn.tsx
@@ -1,0 +1,64 @@
+import { signIn } from "@/lib/auth";
+
+const quotes = [
+  {
+    main: "Rate Your Experience",
+    sub: "Share your insights and help fellow students make informed decisions about their internships and work placements.",
+  },
+];
+
+export default function NotSignIn() {
+  const selectedQuote = quotes[Math.floor(Math.random() * quotes.length)];
+  return (
+    <section className="w-full py-12 md:py-24 lg:py-32 xl:py-48">
+      <div className="container px-4 md:px-6 flex flex-col items-center text-center space-y-6">
+        <div className="flex flex-col space-y-4">
+          <h1 className="text-4xl font-bold tracking-tighter sm:text-5xl xl:text-6xl">
+            {selectedQuote.main}
+          </h1>
+          <p className="md:text-xl ">{selectedQuote.sub}</p>
+        </div>
+
+        <div className="flex flex-col  justify-center gap-2 sm:flex-row">
+          <form
+            action={async () => {
+              "use server";
+              await signIn("42-school");
+            }}
+          >
+            <button className="w-full flex gap-2 h-12  animate-background-shine bg-yellow-600 items-center justify-center rounded-md border border-yellow-700-800 bg-[linear-gradient(110deg,#1a1406,45%,#312a1e,55%,#1a1406)] bg-[length:200%_100%] px-6 font-medium text-gray-400 transition-colors focus:outline-none focus:ring-1 focus:ring-yellow-600 focus:ring-offset-2 focus:ring-offset-yellow-50">
+              <_42Icon className="h-5 w-5" />
+              Sign In with your intra
+            </button>
+          </form>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function _42Icon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M0.799988 15.3149H9.05249V19.4499H13.17V11.9774H4.93249L13.17 3.72241H9.05249L0.799988 11.9774V15.3149Z"
+        fill="white"
+      />
+      <path
+        d="M14.9475 7.85491L19.0675 3.72241H14.9475V7.85491Z"
+        fill="white"
+      />
+      <path
+        d="M19.0675 7.85491L14.9475 11.9774V16.0974H19.0675V11.9774L23.2 7.85491V3.72241H19.0675V7.85491Z"
+        fill="white"
+      />
+      <path d="M23.2 11.9775L19.0675 16.0975H23.2V11.9775Z" fill="white" />
+    </svg>
+  );
+}

--- a/components/review-modal.tsx
+++ b/components/review-modal.tsx
@@ -73,8 +73,9 @@ export function ReviewModalComponent({
       unregister("salaryMax");
     } else {
       setSalaryType("RANGE");
+      unregister("salary");
     }
-  }, [watch("salaryType")]);
+  }, [watch("salaryType"), unregister]);
 
   const onSubmit = async (data: ReviewFormValues) => {
     console.log(data);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -64,8 +64,17 @@ const config: Config = {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "background-shine": {
+          from: {
+            backgroundPosition: "0 0",
+          },
+          to: {
+            backgroundPosition: "-200% 0",
+          },
+        },
       },
       animation: {
+        "background-shine": "background-shine 2s linear infinite",
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },


### PR DESCRIPTION
This pull request includes several changes to the sign-in functionality, layout components, and styling enhancements. The most important changes include refactoring the sign-in process, updating the sign-out functionality, and adding a new animation.

### Sign-in and Sign-out Refactoring:
* [`app/(guest)/signin/page.tsx`](diffhunk://#diff-0c70d087ae9cdc1af9a2ccea4e44914bb8d0230ef9027923e646fc4bc32cf80cL1-R5): Replaced the sign-in form with the `NotSignIn` component to simplify the sign-in process.
* [`components/NotSignIn.tsx`](diffhunk://#diff-747a9a743ece5f6f85d0aba9edd71dd3fb9cdb37924c6bac568c942a09a955b7R1-R65): Created a new `NotSignIn` component that includes a sign-in button and a random quote display.
* [`app/(protected)/layout.tsx`](diffhunk://#diff-78e1c67aebf7259f4e9628b9ee878b6852a45d1ac0d517d126892e00a300ac42L9-R9): Updated the sign-out process to use a form with an async action to properly handle server-side sign-out. [[1]](diffhunk://#diff-78e1c67aebf7259f4e9628b9ee878b6852a45d1ac0d517d126892e00a300ac42L9-R9) [[2]](diffhunk://#diff-78e1c67aebf7259f4e9628b9ee878b6852a45d1ac0d517d126892e00a300ac42L59-R69)

### Styling Enhancements:
* [`tailwind.config.ts`](diffhunk://#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40R67-R77): Added a new `background-shine` animation for visual improvements.

### Miscellaneous:
* [`components/review-modal.tsx`](diffhunk://#diff-968a90c7830adef9081b07a29aea4f071bc2026a0a9525283d0661c2366592c8R76-R78): Fixed a bug by adding `unregister` to the dependency array in the `useEffect` hook to ensure proper cleanup.